### PR TITLE
refactor: use Html::rawElement instead of concatenating strings

### DIFF
--- a/includes/FloatingUI.php
+++ b/includes/FloatingUI.php
@@ -4,6 +4,7 @@ declare( strict_types=1 );
 
 namespace MediaWiki\Extension\FloatingUI;
 
+use MediaWiki\Html\Html;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 
@@ -64,10 +65,9 @@ class FloatingUI {
 		$isInline = true;
 		$wrapperTag = $isInline ? 'span' : 'div';
 
-		$output = <<<HTML
-			<$wrapperTag class='ext-floatingui-reference'>$referenceHtml</$wrapperTag>
-			<$wrapperTag class='ext-floatingui-content'>$floatingHtml</$wrapperTag>
-		HTML;
+		$referenceElement = Html::rawElement( $wrapperTag, [ 'class' => 'ext-floatingui-reference' ], $referenceHtml );
+		$contentElement = Html::rawElement( $wrapperTag, [ 'class' => 'ext-floatingui-content' ], $floatingHtml );
+		$output = $referenceElement . $contentElement;
 
 		return [ $output, 'noparse' => true, 'isHTML' => true ];
 	}


### PR DESCRIPTION
This shouldn't change the behavior of the extension. The main advantages are
* future changes to the code are less likely to introduce XSS vulnerabilities if Html::rawElement is used
* no unnecessary whitespace is created
Before/after:
<img height="200" alt="image" src="https://github.com/user-attachments/assets/21c0b514-1e77-416b-9781-9fdb14c35989" />
<img height="200" alt="image" src="https://github.com/user-attachments/assets/5ba5953d-b3aa-40b6-bc5b-f01771875fe1" />

