### PR TITLE
fix: remove CodeMirror attribute

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -64,12 +64,5 @@
 			"class": "MediaWiki\\Extension\\FloatingUI\\Hooks"
 		}
 	},
-	"attributes": {
-		"CodeMirror": {
-			"TagModes": {
-				"floatingui": "text/mediawiki"
-			}
-		}
-	},
 	"manifest_version": 2
 }


### PR DESCRIPTION
`floatingui` is a parser function, not a tag. Parser functions are always treated as wikitext.