### PR TITLE
chore: add AGENTS.md and wire composer preflight

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,75 @@
+# AGENTS.md
+
+## Overview
+
+FloatingUI is a MediaWiki extension (requires MW 1.43+) that wraps the [Floating UI](https://floating-ui.com/) JavaScript library and exposes it through a `{{#floatingui:reference|floating}}` parser function. PHP renders the reference/floating elements; vanilla JS positions the floating element relative to its reference at runtime via MediaWiki's ResourceLoader. Styles are written in LESS.
+
+## Verification
+
+Run only what's relevant to the files you changed.
+
+| Files changed | Command |
+| --- | --- |
+| `*.php` | `composer preflight` (lint, style, and Phan) |
+| `*.js` | `npm run lint:js` |
+| `*.less`, `*.css` | `npm run lint:styles` |
+| `i18n/` | `npm run lint:i18n` |
+
+Auto-fix commands: `composer fix` (PHP), `npm run lint:fix:js` (JS), `npm run lint:fix:styles` (styles).
+
+**Preflight**: Run `npm run preflight` to execute all Node-based lints in one command. Run `composer preflight` from within a MediaWiki installation to execute all PHP lints, style checks, and Phan static analysis.
+
+**Always run the relevant checks before committing.** Read the full output — PHPCS warnings must be fixed, not just errors. The command exits 0 even with warnings, so do not treat exit code alone as a pass.
+
+### Dev environment
+
+This project's standard dev environment is the MediaWiki Docker setup defined in the parent `mediawiki/` directory. The user may be using a different environment. Ask the user for their dev environment URL and how to run commands if not already known.
+
+To run composer commands in the standard Docker environment:
+
+```sh
+docker compose exec mediawiki bash -c "cd /var/www/html/w/extensions/FloatingUI && composer preflight"
+```
+
+### Phan
+
+Phan requires a full MediaWiki installation at `../../` for type resolution.
+
+```sh
+docker compose exec mediawiki bash -c "cd /var/www/html/w/extensions/FloatingUI && composer phan"
+```
+
+## Coding conventions
+
+### PHP
+
+- All files start with `declare( strict_types=1 );`
+- Use native PHP types (properties, parameters, return values); use PHPDoc only for collection types like `string[]`
+- Always use MediaWiki-namespaced imports (`use MediaWiki\Title\Title;`), never legacy shims (`use Title;`)
+
+### JavaScript
+
+- CommonJS modules: `require()` for imports, `module.exports` for exports
+- Bundled Floating UI library files live under `modules/lib/` and are managed via `ForeignResourcesDir` — do not hand-edit them
+
+### LESS/CSS
+
+- Styles live in `modules/`
+
+### extension.json
+
+`extension.json` is the source of truth for how the extension is wired — ResourceLoader modules, hooks, parser function registration, config variables, and dependencies are all declared here.
+
+- When adding or removing files under `modules/`, update the corresponding `packageFiles` or `styles` list in `extension.json`
+- The `{{#floatingui:...}}` parser function is registered in `includes/Hooks.php` via `ParserFirstCallInit`; its magic word lives in `FloatingUI.magic.php`
+- Config variables (if added) should be prefixed `wgFloatingUI` and declared under `config` in `extension.json`
+
+### Commits
+
+- Use [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `fix:`, `feat:`, `refactor:`)
+- Use `ci:` or `chore:` for non-user-facing changes (tooling, config, dependencies)
+
+### i18n
+
+- Any user-facing string needs a message key in `i18n/en.json`
+- Every key in `en.json` must also have a documentation entry in `i18n/qqq.json`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/composer.json
+++ b/composer.json
@@ -38,12 +38,19 @@
 			"phpcbf"
 		],
 		"test": [
-			"parallel-lint . --exclude vendor --exclude node_modules",
-			"phpcs --config-set ignore_warnings_on_exit 1",
-			"phpcs -p -s",
+			"parallel-lint . --exclude node_modules --exclude vendor",
+			"@phpcs",
 			"minus-x check ."
 		],
-		"phan": "phan -d . --long-progress-bar"
+		"phan": "phan -d . --long-progress-bar",
+		"phpcs": [
+			"phpcs --config-set ignore_warnings_on_exit 1",
+			"phpcs -sp --cache"
+		],
+		"preflight": [
+			"@test",
+			"@phan"
+		]
 	},
 	"extra": {
 		"installer-name": "FloatingUI"

--- a/includes/FloatingUI.php
+++ b/includes/FloatingUI.php
@@ -62,11 +62,8 @@ class FloatingUI {
 		$referenceHtml = self::parseWikitext( $referenceArg, $parser, $frame );
 		$floatingHtml = self::parseWikitext( $floatingArg, $parser, $frame );
 
-		$isInline = true;
-		$wrapperTag = $isInline ? 'span' : 'div';
-
-		$referenceElement = Html::rawElement( $wrapperTag, [ 'class' => 'ext-floatingui-reference' ], $referenceHtml );
-		$contentElement = Html::rawElement( $wrapperTag, [ 'class' => 'ext-floatingui-content' ], $floatingHtml );
+		$referenceElement = Html::rawElement( 'span', [ 'class' => 'ext-floatingui-reference' ], $referenceHtml );
+		$contentElement = Html::rawElement( 'span', [ 'class' => 'ext-floatingui-content' ], $floatingHtml );
 		$output = $referenceElement . $contentElement;
 
 		return [ $output, 'noparse' => true, 'isHTML' => true ];


### PR DESCRIPTION
## Summary
- Add `AGENTS.md` (and `CLAUDE.md` alias) adapted from TabberNeue's, describing the parser-function surface, dev environment, verification commands, and coding conventions.
- Add `composer preflight` script chaining `@test` + `@phan`; extract phpcs into a reusable `@phpcs` script with `--cache`. Mirrors TabberNeue's structure so `composer preflight` is the single PHP entrypoint.
- Drop dead `$isInline` branch in `FloatingUI::parserHook` (it was hardcoded `true`, tripping PhanRedundantCondition — same finding currently failing CI on `ci/use-reusable-workflows`).

## Test plan
- [x] `npm run preflight` passes locally
- [x] `composer preflight` passes inside the MW Docker container (parallel-lint + phpcs + minus-x + phan, all green after the `$isInline` fix)
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)