### PR TITLE
refactor: modernize PHP to 8.1+ syntax and native types

### DIFF
--- a/includes/FloatingUI.php
+++ b/includes/FloatingUI.php
@@ -8,63 +8,34 @@ use MediaWiki\Html\Html;
 use MediaWiki\Parser\Parser;
 use MediaWiki\Parser\PPFrame;
 
-class FloatingUI {
-	/**
-	 * Retrieves and expands the specified argument from the given arguments array using the provided key.
-	 * TODO: Add union typehint (int|string) to $key when we drop PHP 7.4 support
-	 *
-	 * @param int|string $key The key to retrieve the argument from the arguments array.
-	 * @param array $args The array of arguments containing the key-value pairs.
-	 * @param PPFrame $frame The PPFrame object for frame-related operations.
-	 * @return string The expanded argument value if found, otherwise an empty string.
-	 */
-	private static function getArg( $key, array $args, PPFrame $frame ): string {
+final class FloatingUI {
+	private static function getArg( int|string $key, array $args, PPFrame $frame ): string {
 		return $frame->expand( $args[$key] ?? '' );
 	}
 
-	/**
-	 * Parses wikitext content into HTML format.
-	 *
-	 * @param string $wikitext The wikitext content to be parsed.
-	 * @param Parser $parser The Parser object for parsing operations.
-	 * @param PPFrame $frame The PPFrame object for frame-related operations.
-	 * @return string The parsed HTML content.
-	 */
 	private static function parseWikitext( string $wikitext, Parser $parser, PPFrame $frame ): string {
 		$html = $parser->recursiveTagParseFully( $wikitext, $frame );
-		$html = $parser->stripOuterParagraph( $html );
-		return $html;
+		return $parser->stripOuterParagraph( $html );
 	}
 
-	/**
-	 * Parser hook for FloatingUI extension.
-	 *
-	 * @param Parser $parser The parser object.
-	 * @param PPFrame $frame The frame object.
-	 * @param array $args The arguments array.
-	 * @return array The parsed output.
-	 */
 	public static function parserHook( Parser $parser, PPFrame $frame, array $args ): array {
-		// Load Floating UI library
-		$parser->getOutput()->addModules( [ 'ext.floatingUI.lib' ] );
-		// Load main module used to parse HTML
-		$parser->getOutput()->addModuleStyles( [ 'ext.floatingUI.init.styles' ] );
-		$parser->getOutput()->addModules( [ 'ext.floatingUI' ] );
+		$parserOutput = $parser->getOutput();
+		$parserOutput->addModuleStyles( [ 'ext.floatingUI.init.styles' ] );
+		$parserOutput->addModules( [ 'ext.floatingUI.lib', 'ext.floatingUI' ] );
 
 		$referenceArg = self::getArg( 0, $args, $frame );
 		$floatingArg = self::getArg( 1, $args, $frame );
 
-		if ( $referenceArg == '' || $floatingArg == '' ) {
+		if ( $referenceArg === '' || $floatingArg === '' ) {
 			return [];
 		}
 
-		// Parse into wikitext into HTML because we are not parsing the output
+		// Parse wikitext into HTML up front because the parser-function output is returned as raw HTML.
 		$referenceHtml = self::parseWikitext( $referenceArg, $parser, $frame );
 		$floatingHtml = self::parseWikitext( $floatingArg, $parser, $frame );
 
-		$referenceElement = Html::rawElement( 'span', [ 'class' => 'ext-floatingui-reference' ], $referenceHtml );
-		$contentElement = Html::rawElement( 'span', [ 'class' => 'ext-floatingui-content' ], $floatingHtml );
-		$output = $referenceElement . $contentElement;
+		$output = Html::rawElement( 'span', [ 'class' => 'ext-floatingui-reference' ], $referenceHtml )
+			. Html::rawElement( 'span', [ 'class' => 'ext-floatingui-content' ], $floatingHtml );
 
 		return [ $output, 'noparse' => true, 'isHTML' => true ];
 	}

--- a/includes/Hooks.php
+++ b/includes/Hooks.php
@@ -7,7 +7,7 @@ namespace MediaWiki\Extension\FloatingUI;
 use MediaWiki\Hook\ParserFirstCallInitHook;
 use MediaWiki\Parser\Parser;
 
-class Hooks implements ParserFirstCallInitHook {
+final class Hooks implements ParserFirstCallInitHook {
 	/**
 	 * @see https://www.mediawiki.org/wiki/Manual:Hooks/ParserFirstCallInit
 	 *


### PR DESCRIPTION
## Summary
- Mark `FloatingUI` and `Hooks` as `final` — neither is intended for subclassing.
- Add `int|string` union type to `FloatingUI::getArg`'s `\$key` parameter and drop the stale "drop PHP 7.4" TODO (MW 1.43 already requires PHP 8.1+).
- Strip PHPDoc that only restated native parameter/return types, per the AGENTS.md convention.
- Use strict `===` for empty-string checks.
- Cache `\$parser->getOutput()` and merge the two `addModules` calls into one (`ext.floatingUI.lib` + `ext.floatingUI`).

`Hooks::onParserFirstCallInit` keeps its untyped `\$parser` parameter and the matching `@param Parser` PHPDoc — `ParserFirstCallInitHook` declares the parameter untyped, and PHP requires invariant parameter types.

## Test plan
- [x] `composer preflight` (parallel-lint + phpcs + minus-x + phan) passes inside the MW Docker container
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)