### PR TITLE
fix: return text key from empty-args branch

### DIFF
--- a/includes/FloatingUI.php
+++ b/includes/FloatingUI.php
@@ -27,7 +27,7 @@ final class FloatingUI {
 		$floatingArg = self::getArg( 1, $args, $frame );
 
 		if ( $referenceArg === '' || $floatingArg === '' ) {
-			return [];
+			return [ '' ];
 		}
 
 		// Parse wikitext into HTML up front because the parser-function output is returned as raw HTML.


### PR DESCRIPTION
## Summary

- Fix `Undefined array key "text"` warning emitted by Scribunto every time a Lua module invokes `{{#floatingui:…}}` with an empty argument.
- One-line change in `includes/FloatingUI.php`: the empty-args early-return now returns `[ '' ]` instead of `[]`, which gets promoted to `'text' => ''` by core.

## Why

Tracing a high-volume PHP warning on a wiki running this extension:

```
PHP Warning: Undefined array key "text" in
/var/www/mediawiki/extensions/Scribunto/includes/Engines/LuaCommon/LuaEngine.php
on line 818
```

The chain:

1. A wiki Lua module calls `frame:callParserFunction( '#floatingui', { ref, '' } )` with one empty argument.
2. The parser hook hits the early-return at the top of `parserHook()` and returns `[]`.
3. `Parser::callParserFunction()` (MediaWiki core, REL1_43 lines 3434–3450) only promotes `$result[0]` to `'text'` when `isset( $result[0] )`. An empty array has no `[0]`, so the returned array is just `[ 'found' => true ]` — no `text` key.
4. Scribunto's `LuaEngine::callParserFunction()` (REL1_43 line 818, master line 942) sets defaults for `nowiki`, `isChildObj`, `isLocalObj`, `isHTML`, `title` — but not `text` — then immediately reads `$result['text']`. PHP 8 raises the warning.

Note: the bug only surfaces from Lua-call paths. Direct wikitext use of `{{#floatingui:|}}` does not reach Scribunto's LuaEngine, so the warning is invisible to wiki editors. It floods PHP-FPM and jobrunner logs (we caught it doing 547+ warnings/hour on a single wiki during `refreshLinks` and `cirrusSearchElasticaWrite` job runs).

## The fix

```diff
 if ( $referenceArg === '' || $floatingArg === '' ) {
-    return [];
+    return [ '' ];
 }
```

`[ '' ]` keeps the "produce no output" semantics — `$result[0] = ''` is promoted to `'text' => ''` by `Parser::callParserFunction()`, and Scribunto reads an empty string instead of warning. No behavior change for callers; no change to wikitext output.

The underlying defensive-coding gap in Scribunto's defaults block is arguably worth fixing upstream too, but that is a separate concern: the parser-function contract permits result arrays without `text`, and this hook was the one violating it for the empty-args case.

## Test plan

- [x] `composer preflight` (lint, style, Phan) — single-line change, no expected diff in lint output
- [x] In a wiki environment with Scribunto + the extension installed: confirm a Lua module calling `frame:callParserFunction( '#floatingui', { '', '' } )` no longer triggers the warning
- [x] Confirm `{{#floatingui:|}}` direct wikitext still renders nothing (no regression)
- [x] Confirm the normal `{{#floatingui:ref|float}}` path is unaffected (this branch is only hit when at least one arg is empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)