### PR TITLE
fix: trim whitespace from parser function arguments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
           files_yaml: |
             php:
               - includes/**/*.php
+              - tests/**/*.php
+              - tests/parser/**/*.txt
               - extension.json
               - composer.json
               - composer.lock
@@ -75,6 +77,15 @@ jobs:
     needs: changes
     if: needs.changes.outputs.php == 'true'
     uses: StarCitizenTools/mediawiki-ci-workflows/.github/workflows/analyze-php.yml@main
+    with:
+      project-type: extension
+      project-name: FloatingUI
+      runner: ubuntu-24.04-arm
+
+  test-parser:
+    needs: changes
+    if: needs.changes.outputs.php == 'true'
+    uses: StarCitizenTools/mediawiki-ci-workflows/.github/workflows/test-parser.yml@main
     with:
       project-type: extension
       project-name: FloatingUI

--- a/extension.json
+++ b/extension.json
@@ -64,5 +64,8 @@
 			"class": "MediaWiki\\Extension\\FloatingUI\\Hooks"
 		}
 	},
+	"ParserTestFiles": [
+		"tests/parser/floatingui.txt"
+	],
 	"manifest_version": 2
 }

--- a/includes/FloatingUI.php
+++ b/includes/FloatingUI.php
@@ -10,7 +10,13 @@ use MediaWiki\Parser\PPFrame;
 
 final class FloatingUI {
 	private static function getArg( int|string $key, array $args, PPFrame $frame ): string {
-		return $frame->expand( $args[$key] ?? '' );
+		// Trim surrounding whitespace: with SFH_OBJECT_ARGS, MediaWiki passes arguments after the
+		// first as raw, untrimmed PPNodes, so `{{#floatingui: a | b }}` would otherwise expand the
+		// second argument to " b ". A leading space makes recursiveTagParseFully() emit a <pre>
+		// block; MediaWiki's HTML tidy pass then moves that block out of the wrapping paragraph,
+		// leaving the content span no longer adjacent to the reference span, so the client-side
+		// findContentEl() can no longer locate it and the tooltip never gets wired up.
+		return trim( $frame->expand( $args[$key] ?? '' ) );
 	}
 
 	private static function parseWikitext( string $wikitext, Parser $parser, PPFrame $frame ): string {

--- a/tests/parser/floatingui.txt
+++ b/tests/parser/floatingui.txt
@@ -1,0 +1,34 @@
+!! version 2
+
+# FloatingUI parser tests
+#
+# The {{#floatingui:reference|floating}} parser function renders two adjacent
+# spans (.ext-floatingui-reference + .ext-floatingui-content). Arguments must be
+# trimmed: a leading space would otherwise make recursiveTagParseFully() emit a
+# <pre> block, which the tidy pass hoists out of the wrapping paragraph and
+# breaks the reference/content adjacency the client-side JS relies on.
+
+!! test
+FloatingUI: reference and floating content without surrounding whitespace
+!! wikitext
+{{#floatingui:lol|wow}}
+!! html
+<p><span class="ext-floatingui-reference">lol</span><span class="ext-floatingui-content">wow</span>
+</p>
+!! end
+
+!! test
+FloatingUI: surrounding whitespace around arguments is trimmed
+!! wikitext
+{{#floatingui: lol | wow }}
+!! html
+<p><span class="ext-floatingui-reference">lol</span><span class="ext-floatingui-content">wow</span>
+</p>
+!! end
+
+!! test
+FloatingUI: whitespace-only floating argument yields no output
+!! wikitext
+{{#floatingui: lol | }}
+!! html
+!! end


### PR DESCRIPTION
## Summary

`{{#floatingui: lol | wow }}` (spaces around the `|`) rendered **no tooltip**, while `{{#floatingui:lol|wow}}` (no spaces) worked. Both should behave identically. This trims parser-function arguments so they do, and adds parser tests + CI to lock the regression down.

## Root cause

The parser function is registered with `Parser::SFH_OBJECT_ARGS`. In that mode MediaWiki passes arguments **after the first** as raw, **untrimmed** `PPNode`s (the non-`SFH_OBJECT_ARGS` path does `trim( $frame->expand( $v ) )`; the object path does not). The first argument, after the `:`, is pre-trimmed by core, which is why only the argument(s) after the first `|` carried whitespace.

So `getArg()` expanded the floating argument to `" wow "`. A leading space makes `recursiveTagParseFully()` emit a `<pre>` block (and `stripOuterParagraph()` doesn't strip `<pre>`). MediaWiki's HTML tidy pass then corrects the invalid `<pre>`-inside-`<p>` nesting by closing the paragraph right after the reference span — pushing the content span *out* of the paragraph:

```html
<!-- before fix, server-rendered -->
<p><span class="ext-floatingui-reference">lol</span></p><span class="ext-floatingui-content"><pre>wow </pre></span>
```

The client-side `findContentEl()` walks `referenceEl.nextElementSibling` looking for `.ext-floatingui-content`. Now the reference span is the only child of its `<p>`, so `nextElementSibling` is `null`, `findContentEl()` returns `undefined`, `init()` bails, and **no listeners are attached** — the tooltip never triggers.

## Fix

Wrap `getArg()`'s expansion in `trim()`. This matches MediaWiki core's documented `SFH_OBJECT_ARGS` contract ("If you want whitespace to be trimmed from `$args`, you need to do it yourself, post-expansion") and its default `trim()` charset.

## Behaviour change

Whitespace-only arguments (e.g. `{{#floatingui: lol | }}`) now correctly count as empty and hit the existing empty-args short-circuit, instead of rendering a broken `<pre>`-only span. Intentional escapes still work — `<nowiki>`-wrapped or entity-encoded whitespace survives, since strip markers / `&#32;` aren't in `trim()`'s charset.

## Tests + CI

Adds `tests/parser/floatingui.txt` (registered via `ParserTestFiles`) with three cases:
- reference + floating content without surrounding whitespace
- surrounding whitespace around arguments is trimmed *(this is the regression)*
- whitespace-only floating argument yields no output

The two whitespace cases **fail against the pre-fix code** and pass with the fix (verified locally against MediaWiki 1.43 via `tests/parser/parserTests.php`). A `test-parser` CI job (shared `test-parser.yml` workflow, matching TabberNeue) runs them on every PHP-affecting change.

## Verification

End-to-end render (real MediaWiki 1.43) — both inputs now produce **byte-identical** output:

```html
<p><span class="ext-floatingui-reference">lol</span><span class="ext-floatingui-content">wow</span></p>
```

`composer preflight` equivalent all green: `parallel-lint`, `phpcs` (no warnings), `minus-x`, and Phan (exit 0, no issues). Parser tests: 3/3 pass with the fix; 2/3 fail without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)