### PR TITLE
fix: dead space from empty #mw-teleport-target container

### DIFF
--- a/modules/ext.floatingUI/ext.floatingUI.less
+++ b/modules/ext.floatingUI/ext.floatingUI.less
@@ -5,15 +5,11 @@
 }
 
 .ext-floatingui-floating {
+	position: absolute;
+	top: 0;
+	left: 0;
+	z-index: @z-index-tooltip;
 	max-width: calc( 100vw - @spacing-200 );
-
-	/* If teleportTarget is not set, then position the floating element ourselves */
-	body > & {
-		position: absolute;
-		top: 0;
-		left: 0;
-		z-index: @z-index-tooltip;
-	}
 }
 
 .ext-floatingui-floating-inner {

--- a/modules/ext.floatingUI/ext.floatingUI.less
+++ b/modules/ext.floatingUI/ext.floatingUI.less
@@ -9,6 +9,7 @@
 	top: 0;
 	left: 0;
 	z-index: @z-index-tooltip;
+	width: max-content;
 	max-width: calc( 100vw - @spacing-200 );
 }
 


### PR DESCRIPTION
fixes #mw-teleport-target taking up dead space underneath the site footer when floatingui is in use (which in some cases extends the page, causing a scrollbar which can shift the page, and thats especially annoying with small hover targets)

<img width="690" height="207" alt="image" src="https://github.com/user-attachments/assets/6114dcaf-7c54-48b0-bc9c-f9874c9224b0" />

<img width="225" height="95" alt="image" src="https://github.com/user-attachments/assets/8d95e1d9-f50c-402b-9d32-b7ce12bc9339" />
