### PR TITLE
ci: add scheduled foreign resources update workflow

### DIFF
--- a/.github/workflows/update-foreign-resources.yml
+++ b/.github/workflows/update-foreign-resources.yml
@@ -1,0 +1,21 @@
+name: Update foreign resources
+
+on:
+  schedule:
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+
+jobs:
+  update:
+    uses: StarCitizenTools/mediawiki-ci-workflows/.github/workflows/update-foreign-resources.yml@main
+    permissions:
+      contents: write
+      pull-requests: write
+    with:
+      project-type: extension
+      project-name: FloatingUI
+      pr-title: "fix(deps): update Floating UI foreign resources"
+    # Empty until the org defines PR_TOKEN (which would let update PRs
+    # trigger CI); the workflow then falls back to GITHUB_TOKEN.
+    secrets:
+      PR_TOKEN: ${{ secrets.PR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /vendor
 /node_modules
 .eslintcache
+.foreign/


### PR DESCRIPTION
Wires FloatingUI up to the shared `update-foreign-resources.yml` workflow (StarCitizenTools/mediawiki-ci-workflows#15): weekly on Mondays 06:00 UTC plus manual dispatch, opening an update PR whenever a newer Floating UI release is on npm.

- `pr-title` is overridden to `fix(deps): …` so merged update PRs cut a release-please patch release — the bundled library is shipped to users, unlike dev-dependency bumps.
- `PR_TOKEN` is forwarded explicitly; until the org defines that secret it is empty and the workflow falls back to `GITHUB_TOKEN`.
- `.foreign/` added to `.gitignore` — `manageForeignResources` caches downloads in `modules/lib/.foreign/cache` when `XDG_CACHE_HOME`/`$wgCacheDirectory` are unset, which protects manual local runs.

**Depends on StarCitizenTools/mediawiki-ci-workflows#15** — the referenced reusable workflow must exist on `main` first. Also requires the "Allow GitHub Actions to create and approve pull requests" setting (Settings → Actions → General).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
