### PR TITLE
fix(deps): bump @floating-ui/core to 1.8.0 and @floating-ui/dom to 1.8.0

### DIFF
--- a/modules/lib/floatingui-core/floating-ui.core.umd.js
+++ b/modules/lib/floatingui-core/floating-ui.core.umd.js
@@ -98,12 +98,12 @@
     return oppositeSideMap[side] + placement.slice(side.length);
   }
   function expandPaddingObject(padding) {
+    var _padding$top, _padding$right, _padding$bottom, _padding$left;
     return {
-      top: 0,
-      right: 0,
-      bottom: 0,
-      left: 0,
-      ...padding
+      top: (_padding$top = padding.top) != null ? _padding$top : 0,
+      right: (_padding$right = padding.right) != null ? _padding$right : 0,
+      bottom: (_padding$bottom = padding.bottom) != null ? _padding$bottom : 0,
+      left: (_padding$left = padding.left) != null ? _padding$left : 0
     };
   }
   function getPaddingObject(padding) {
@@ -178,13 +178,9 @@
           y: reference.y
         };
     }
-    switch (getAlignment(placement)) {
-      case 'start':
-        coords[alignmentAxis] -= commonAlign * (rtl && isVertical ? -1 : 1);
-        break;
-      case 'end':
-        coords[alignmentAxis] += commonAlign * (rtl && isVertical ? -1 : 1);
-        break;
+    const alignment = getAlignment(placement);
+    if (alignment) {
+      coords[alignmentAxis] += commonAlign * (alignment === 'end' ? 1 : -1) * (rtl && isVertical ? -1 : 1);
     }
     return coords;
   }
@@ -233,10 +229,7 @@
       height: rects.floating.height
     } : rects.reference;
     const offsetParent = await (platform.getOffsetParent == null ? void 0 : platform.getOffsetParent(elements.floating));
-    const offsetScale = (await (platform.isElement == null ? void 0 : platform.isElement(offsetParent))) ? (await (platform.getScale == null ? void 0 : platform.getScale(offsetParent))) || {
-      x: 1,
-      y: 1
-    } : {
+    const offsetScale = (await (platform.isElement == null ? void 0 : platform.isElement(offsetParent))) && (await (platform.getScale == null ? void 0 : platform.getScale(offsetParent))) || {
       x: 1,
       y: 1
     };
@@ -409,17 +402,16 @@
 
       // Make sure the arrow doesn't overflow the floating element if the center
       // point is outside the floating element's bounds.
-      const min$1 = minPadding;
       const max = clientSize - arrowDimensions[length] - maxPadding;
       const center = clientSize / 2 - arrowDimensions[length] / 2 + centerToReference;
-      const offset = clamp(min$1, center, max);
+      const offset = clamp(minPadding, center, max);
 
       // If the reference is small enough that the arrow's padding causes it to
       // to point to nothing for an aligned placement, adjust the offset of the
       // floating element itself. To ensure `shift()` continues to take action,
       // a single reset is performed when this is true.
-      const shouldAddOffset = !middlewareData.arrow && getAlignment(placement) != null && center !== offset && rects.reference[length] / 2 - (center < min$1 ? minPadding : maxPadding) - arrowDimensions[length] / 2 < 0;
-      const alignmentOffset = shouldAddOffset ? center < min$1 ? center - min$1 : center - max : 0;
+      const shouldAddOffset = !middlewareData.arrow && getAlignment(placement) != null && center !== offset && rects.reference[length] / 2 - (center < minPadding ? minPadding : maxPadding) - arrowDimensions[length] / 2 < 0;
+      const alignmentOffset = shouldAddOffset ? center < minPadding ? center - minPadding : center - max : 0;
       return {
         [axis]: coords[axis] + alignmentOffset,
         data: {
@@ -473,13 +465,11 @@
           ...detectOverflowOptions
         } = evaluate(options, state);
         const placements$1 = alignment !== undefined || allowedPlacements === placements ? getPlacementList(alignment || null, autoAlignment, allowedPlacements) : allowedPlacements;
-        const overflow = await platform.detectOverflow(state, detectOverflowOptions);
         const currentIndex = ((_middlewareData$autoP = middlewareData.autoPlacement) == null ? void 0 : _middlewareData$autoP.index) || 0;
         const currentPlacement = placements$1[currentIndex];
         if (currentPlacement == null) {
           return {};
         }
-        const alignmentSides = getAlignmentSides(currentPlacement, rects, await (platform.isRTL == null ? void 0 : platform.isRTL(elements.floating)));
 
         // Make `computeCoords` start from the right place.
         if (placement !== currentPlacement) {
@@ -489,6 +479,8 @@
             }
           };
         }
+        const overflow = await platform.detectOverflow(state, detectOverflowOptions);
+        const alignmentSides = getAlignmentSides(currentPlacement, rects, await (platform.isRTL == null ? void 0 : platform.isRTL(elements.floating)));
         const currentOverflows = [overflow[getSide(currentPlacement)], overflow[alignmentSides[0]], overflow[alignmentSides[1]]];
         const allOverflows = [...(((_middlewareData$autoP2 = middlewareData.autoPlacement) == null ? void 0 : _middlewareData$autoP2.overflows) || []), {
           placement: currentPlacement,
@@ -795,12 +787,19 @@
           y
         } = evaluate(options, state);
         const nativeClientRects = Array.from((await (platform.getClientRects == null ? void 0 : platform.getClientRects(elements.reference))) || []);
+
+        // No rects (e.g. a hidden or detached reference, or a collapsed range) —
+        // keep the existing reference rect rather than resetting to an invalid
+        // one with non-finite values.
+        if (!nativeClientRects.length) {
+          return {};
+        }
         const clientRects = getRectsByLine(nativeClientRects);
         const fallback = rectToClientRect(getBoundingRect(nativeClientRects));
         const paddingObject = getPaddingObject(padding);
         function getBoundingClientRect() {
           // There are two rects and they are disjoined.
-          if (clientRects.length === 2 && clientRects[0].left > clientRects[1].right && x != null && y != null) {
+          if (clientRects.length === 2 && (clientRects[0].left > clientRects[1].right || clientRects[1].left > clientRects[0].right) && x != null && y != null) {
             // Find the first rect in which the point is fully inside.
             return clientRects.find(rect => x > rect.left - paddingObject.left && x < rect.right + paddingObject.right && y > rect.top - paddingObject.top && y < rect.bottom + paddingObject.bottom) || fallback;
           }
@@ -815,18 +814,12 @@
               const bottom = lastRect.bottom;
               const left = isTop ? firstRect.left : lastRect.left;
               const right = isTop ? firstRect.right : lastRect.right;
-              const width = right - left;
-              const height = bottom - top;
-              return {
-                top,
-                bottom,
-                left,
-                right,
-                width,
-                height,
+              return rectToClientRect({
                 x: left,
-                y: top
-              };
+                y: top,
+                width: right - left,
+                height: bottom - top
+              });
             }
             const isLeftSide = getSide(placement) === 'left';
             const maxRight = max(...clientRects.map(rect => rect.right));
@@ -834,20 +827,12 @@
             const measureRects = clientRects.filter(rect => isLeftSide ? rect.left === minLeft : rect.right === maxRight);
             const top = measureRects[0].top;
             const bottom = measureRects[measureRects.length - 1].bottom;
-            const left = minLeft;
-            const right = maxRight;
-            const width = right - left;
-            const height = bottom - top;
-            return {
-              top,
-              bottom,
-              left,
-              right,
-              width,
-              height,
-              x: left,
-              y: top
-            };
+            return rectToClientRect({
+              x: minLeft,
+              y: top,
+              width: maxRight - minLeft,
+              height: bottom - top
+            });
           }
           return fallback;
         }
@@ -997,23 +982,16 @@
           y
         };
         const overflow = await platform.detectOverflow(state, detectOverflowOptions);
-        const crossAxis = getSideAxis(getSide(placement));
+        const crossAxis = getSideAxis(placement);
         const mainAxis = getOppositeAxis(crossAxis);
         let mainAxisCoord = coords[mainAxis];
         let crossAxisCoord = coords[crossAxis];
+        const clampCoord = (axis, coord) => clamp(coord + overflow[axis === 'y' ? 'top' : 'left'], coord, coord - overflow[axis === 'y' ? 'bottom' : 'right']);
         if (checkMainAxis) {
-          const minSide = mainAxis === 'y' ? 'top' : 'left';
-          const maxSide = mainAxis === 'y' ? 'bottom' : 'right';
-          const min = mainAxisCoord + overflow[minSide];
-          const max = mainAxisCoord - overflow[maxSide];
-          mainAxisCoord = clamp(min, mainAxisCoord, max);
+          mainAxisCoord = clampCoord(mainAxis, mainAxisCoord);
         }
         if (checkCrossAxis) {
-          const minSide = crossAxis === 'y' ? 'top' : 'left';
-          const maxSide = crossAxis === 'y' ? 'bottom' : 'right';
-          const min = crossAxisCoord + overflow[minSide];
-          const max = crossAxisCoord - overflow[maxSide];
-          crossAxisCoord = clamp(min, crossAxisCoord, max);
+          crossAxisCoord = clampCoord(crossAxis, crossAxisCoord);
         }
         const limitedCoords = limiter.fn({
           ...state,
@@ -1044,6 +1022,7 @@
     return {
       options,
       fn(state) {
+        var _rawOffset$mainAxis, _rawOffset$crossAxis;
         const {
           x,
           y,
@@ -1069,9 +1048,8 @@
           mainAxis: rawOffset,
           crossAxis: 0
         } : {
-          mainAxis: 0,
-          crossAxis: 0,
-          ...rawOffset
+          mainAxis: (_rawOffset$mainAxis = rawOffset.mainAxis) != null ? _rawOffset$mainAxis : 0,
+          crossAxis: (_rawOffset$crossAxis = rawOffset.crossAxis) != null ? _rawOffset$crossAxis : 0
         };
         if (checkMainAxis) {
           const len = mainAxis === 'y' ? 'height' : 'width';
@@ -1103,6 +1081,12 @@
     };
   };
 
+  // Method syntax keeps callback parameters bivariant, but expressing the
+  // explicit `| undefined` required by `exactOptionalPropertyTypes` needs
+  // property syntax, which is contravariant under `strictFunctionTypes`.
+  // Extracting the function from a method position restores that bivariance so
+  // consumers can still assign callbacks with narrower parameter types.
+
   /**
    * Provides data that allows you to change the size of the floating element —
    * for instance, prevent it from overflowing the clipping boundary or match the
@@ -1117,7 +1101,6 @@
       name: 'size',
       options,
       async fn(state) {
-        var _state$middlewareData, _state$middlewareData2;
         const {
           placement,
           rects,
@@ -1149,24 +1132,21 @@
         const maximumClippingWidth = width - overflow.left - overflow.right;
         const overflowAvailableHeight = min(height - overflow[heightSide], maximumClippingHeight);
         const overflowAvailableWidth = min(width - overflow[widthSide], maximumClippingWidth);
-        const noShift = !state.middlewareData.shift;
+        const shiftData = state.middlewareData.shift;
+        const noShift = !shiftData;
         let availableHeight = overflowAvailableHeight;
         let availableWidth = overflowAvailableWidth;
-        if ((_state$middlewareData = state.middlewareData.shift) != null && _state$middlewareData.enabled.x) {
+        if (shiftData != null && shiftData.enabled.x) {
           availableWidth = maximumClippingWidth;
         }
-        if ((_state$middlewareData2 = state.middlewareData.shift) != null && _state$middlewareData2.enabled.y) {
+        if (shiftData != null && shiftData.enabled.y) {
           availableHeight = maximumClippingHeight;
         }
         if (noShift && !alignment) {
-          const xMin = max(overflow.left, 0);
-          const xMax = max(overflow.right, 0);
-          const yMin = max(overflow.top, 0);
-          const yMax = max(overflow.bottom, 0);
           if (isYAxis) {
-            availableWidth = width - 2 * (xMin !== 0 || xMax !== 0 ? xMin + xMax : max(overflow.left, overflow.right));
+            availableWidth = width - 2 * max(overflow.left, overflow.right);
           } else {
-            availableHeight = height - 2 * (yMin !== 0 || yMax !== 0 ? yMin + yMax : max(overflow.top, overflow.bottom));
+            availableHeight = height - 2 * max(overflow.top, overflow.bottom);
           }
         }
         await apply({

--- a/modules/lib/floatingui-dom/floating-ui.dom.umd.js
+++ b/modules/lib/floatingui-dom/floating-ui.dom.umd.js
@@ -153,7 +153,7 @@
   function getNearestOverflowAncestor(node) {
     const parentNode = getParentNode(node);
     if (isLastTraversableNode(parentNode)) {
-      return node.ownerDocument ? node.ownerDocument.body : node.body;
+      return (node.ownerDocument || node).body;
     }
     if (isHTMLElement(parentNode) && isOverflowElement(parentNode)) {
       return parentNode;
@@ -250,10 +250,7 @@
     if (isFixed === void 0) {
       isFixed = false;
     }
-    if (!floatingOffsetParent || isFixed && floatingOffsetParent !== getWindow(element)) {
-      return false;
-    }
-    return isFixed;
+    return !!floatingOffsetParent && isFixed && floatingOffsetParent === getWindow(element);
   }
 
   function getBoundingClientRect(element, includeScale, isFixedStrategy, offsetParent) {
@@ -280,12 +277,12 @@
     let y = (clientRect.top + visualOffsets.y) / scale.y;
     let width = clientRect.width / scale.x;
     let height = clientRect.height / scale.y;
-    if (domElement) {
+    if (domElement && offsetParent) {
       const win = getWindow(domElement);
-      const offsetWin = offsetParent && isElement(offsetParent) ? getWindow(offsetParent) : offsetParent;
+      const offsetWin = isElement(offsetParent) ? getWindow(offsetParent) : offsetParent;
       let currentWin = win;
       let currentIFrame = getFrameElement(currentWin);
-      while (currentIFrame && offsetParent && offsetWin !== currentWin) {
+      while (currentIFrame && offsetWin !== currentWin) {
         const iframeScale = getScale(currentIFrame);
         const iframeRect = currentIFrame.getBoundingClientRect();
         const css = getComputedStyle$1(currentIFrame);
@@ -349,7 +346,7 @@
     let scale = createCoords(1);
     const offsets = createCoords(0);
     const isOffsetParentAnElement = isHTMLElement(offsetParent);
-    if (isOffsetParentAnElement || !isOffsetParentAnElement && !isFixed) {
+    if (isOffsetParentAnElement || !isFixed) {
       if (getNodeName(offsetParent) !== 'body' || isOverflowElement(documentElement)) {
         scroll = getNodeScroll(offsetParent);
       }
@@ -370,18 +367,17 @@
   }
 
   function getClientRects(element) {
-    return Array.from(element.getClientRects());
+    return element.getClientRects ? Array.from(element.getClientRects()) : [];
   }
 
   // Gets the entire size of the scrollable document area, even extending outside
   // of the `<html>` and `<body>` rect bounds if horizontally scrollable.
-  function getDocumentRect(element) {
-    const html = getDocumentElement(element);
-    const scroll = getNodeScroll(element);
-    const body = element.ownerDocument.body;
+  function getDocumentRect(html) {
+    const scroll = getNodeScroll(html);
+    const body = html.ownerDocument.body;
     const width = max(html.scrollWidth, html.clientWidth, body.scrollWidth, body.clientWidth);
     const height = max(html.scrollHeight, html.clientHeight, body.scrollHeight, body.clientHeight);
-    let x = -scroll.scrollLeft + getWindowScrollBarX(element);
+    let x = -scroll.scrollLeft + getWindowScrollBarX(html);
     const y = -scroll.scrollTop;
     if (getComputedStyle$1(body).direction === 'rtl') {
       x += max(html.clientWidth, body.clientWidth) - width;
@@ -398,7 +394,11 @@
   // calculation is affected by unusual styles.
   // Most scrollbars leave 15-18px of space.
   const SCROLLBAR_MAX = 25;
-  function getViewportRect(element, strategy) {
+  function getViewportRect(element, strategy, rootBoundary) {
+    if (rootBoundary === void 0) {
+      rootBoundary = 'viewport';
+    }
+    const isLayoutViewport = rootBoundary === 'layoutViewport';
     const win = getWindow(element);
     const html = getDocumentElement(element);
     const visualViewport = win.visualViewport;
@@ -407,31 +407,42 @@
     let x = 0;
     let y = 0;
     if (visualViewport) {
-      width = visualViewport.width;
-      height = visualViewport.height;
-      const visualViewportBased = isWebKit();
-      if (!visualViewportBased || visualViewportBased && strategy === 'fixed') {
-        x = visualViewport.offsetLeft;
-        y = visualViewport.offsetTop;
+      // Client coordinates are relative to the layout viewport, except in
+      // WebKit with an `absolute` strategy, where they are relative to the
+      // visual viewport.
+      const layoutRelativeClientCoords = !isWebKit() || strategy === 'fixed';
+      if (isLayoutViewport) {
+        if (!layoutRelativeClientCoords) {
+          x = -visualViewport.offsetLeft;
+          y = -visualViewport.offsetTop;
+        }
+      } else {
+        width = visualViewport.width;
+        height = visualViewport.height;
+        if (layoutRelativeClientCoords) {
+          x = visualViewport.offsetLeft;
+          y = visualViewport.offsetTop;
+        }
       }
     }
     const windowScrollbarX = getWindowScrollBarX(html);
-    // <html> `overflow: hidden` + `scrollbar-gutter: stable` reduces the
-    // visual width of the <html> but this is not considered in the size
-    // of `html.clientWidth`.
+    // `scrollbar-gutter: stable` on the <html> reserves gutter space that shrinks
+    // the visual width but isn't reflected in `html.clientWidth`, so subtract it.
+    // Only the inline-end (right) gutter can hold the scrollbar; `both-edges` also
+    // reserves an empty inline-start gutter that clips nothing, so exclude just
+    // the one scrollbar-side gutter — halve the measured (two-gutter) total. A
+    // left-side scrollbar (`windowScrollbarX > 0`) is already handled by
+    // `getHTMLOffset`/`visualViewport.width`; skip it here.
     if (windowScrollbarX <= 0) {
       const doc = html.ownerDocument;
       const body = doc.body;
       const bodyStyles = getComputedStyle(body);
       const bodyMarginInline = doc.compatMode === 'CSS1Compat' ? parseFloat(bodyStyles.marginLeft) + parseFloat(bodyStyles.marginRight) || 0 : 0;
-      const clippingStableScrollbarWidth = Math.abs(html.clientWidth - body.clientWidth - bodyMarginInline);
-      if (clippingStableScrollbarWidth <= SCROLLBAR_MAX) {
-        width -= clippingStableScrollbarWidth;
+      const reservedWidth = Math.abs(html.clientWidth - body.clientWidth - bodyMarginInline);
+      const gutter = getComputedStyle(html).scrollbarGutter === 'stable both-edges' ? reservedWidth / 2 : reservedWidth;
+      if (gutter <= SCROLLBAR_MAX) {
+        width -= gutter;
       }
-    } else if (windowScrollbarX <= SCROLLBAR_MAX) {
-      // If the <body> scrollbar is on the left, the width needs to be extended
-      // by the scrollbar amount so there isn't extra space on the right.
-      width += windowScrollbarX;
     }
     return {
       width,
@@ -446,7 +457,7 @@
     const clientRect = getBoundingClientRect(element, true, strategy === 'fixed');
     const top = clientRect.top + element.clientTop;
     const left = clientRect.left + element.clientLeft;
-    const scale = isHTMLElement(element) ? getScale(element) : createCoords(1);
+    const scale = getScale(element);
     const width = element.clientWidth * scale.x;
     const height = element.clientHeight * scale.y;
     const x = left * scale.x;
@@ -460,8 +471,8 @@
   }
   function getClientRectFromClippingAncestor(element, clippingAncestor, strategy) {
     let rect;
-    if (clippingAncestor === 'viewport') {
-      rect = getViewportRect(element, strategy);
+    if (clippingAncestor === 'viewport' || clippingAncestor === 'layoutViewport') {
+      rect = getViewportRect(element, strategy, clippingAncestor);
     } else if (clippingAncestor === 'document') {
       rect = getDocumentRect(getDocumentElement(element));
     } else if (isElement(clippingAncestor)) {
@@ -477,13 +488,6 @@
     }
     return core.rectToClientRect(rect);
   }
-  function hasFixedPositionAncestor(element, stopNode) {
-    const parentNode = getParentNode(element);
-    if (parentNode === stopNode || !isElement(parentNode) || isLastTraversableNode(parentNode)) {
-      return false;
-    }
-    return getComputedStyle$1(parentNode).position === 'fixed' || hasFixedPositionAncestor(parentNode, stopNode);
-  }
 
   // A "clipping ancestor" is an `overflow` element with the characteristic of
   // clipping (or hiding) child elements. This returns all clipping ancestors
@@ -494,7 +498,7 @@
       return cachedResult;
     }
     let result = getOverflowAncestors(element, [], false).filter(el => isElement(el) && getNodeName(el) !== 'body');
-    let currentContainingBlockComputedStyle = null;
+    let lastKeptComputedStyle = null;
     const elementIsFixed = getComputedStyle$1(element).position === 'fixed';
     let currentNode = elementIsFixed ? getParentNode(element) : element;
 
@@ -502,16 +506,20 @@
     while (isElement(currentNode) && !isLastTraversableNode(currentNode)) {
       const computedStyle = getComputedStyle$1(currentNode);
       const currentNodeIsContaining = isContainingBlock(currentNode);
-      if (!currentNodeIsContaining && computedStyle.position === 'fixed') {
-        currentContainingBlockComputedStyle = null;
-      }
-      const shouldDropCurrentNode = elementIsFixed ? !currentNodeIsContaining && !currentContainingBlockComputedStyle : !currentNodeIsContaining && computedStyle.position === 'static' && !!currentContainingBlockComputedStyle && (currentContainingBlockComputedStyle.position === 'absolute' || currentContainingBlockComputedStyle.position === 'fixed') || isOverflowElement(currentNode) && !currentNodeIsContaining && hasFixedPositionAncestor(element, currentNode);
+      // Position of the containing block chain below the current node. A fixed
+      // element whose containing block hasn't been found yet is a fixed chain.
+      const lastPosition = lastKeptComputedStyle ? lastKeptComputedStyle.position : elementIsFixed ? 'fixed' : '';
+
+      // A non-containing ancestor does not clip the element when the chain
+      // below it escapes it: a fixed chain escapes all ancestors up to the
+      // next containing block, an absolute chain escapes static ancestors.
+      const shouldDropCurrentNode = !currentNodeIsContaining && (lastPosition === 'fixed' || lastPosition === 'absolute' && computedStyle.position === 'static');
       if (shouldDropCurrentNode) {
         // Drop non-containing blocks.
         result = result.filter(ancestor => ancestor !== currentNode);
       } else {
-        // Record last containing block for next iteration.
-        currentContainingBlockComputedStyle = computedStyle;
+        // The kept node carries the chain position for the next iteration.
+        lastKeptComputedStyle = computedStyle;
       }
       currentNode = getParentNode(currentNode);
     }
@@ -571,13 +579,7 @@
       scrollTop: 0
     };
     const offsets = createCoords(0);
-
-    // If the <body> scrollbar appears on the left (e.g. RTL systems). Use
-    // Firefox with layout.scrollbar.side = 3 in about:config to test this.
-    function setLeftRTLScrollbarOffset() {
-      offsets.x = getWindowScrollBarX(documentElement);
-    }
-    if (isOffsetParentAnElement || !isOffsetParentAnElement && !isFixed) {
+    if (isOffsetParentAnElement || !isFixed) {
       if (getNodeName(offsetParent) !== 'body' || isOverflowElement(documentElement)) {
         scroll = getNodeScroll(offsetParent);
       }
@@ -585,12 +587,13 @@
         const offsetRect = getBoundingClientRect(offsetParent, true, isFixed, offsetParent);
         offsets.x = offsetRect.x + offsetParent.clientLeft;
         offsets.y = offsetRect.y + offsetParent.clientTop;
-      } else if (documentElement) {
-        setLeftRTLScrollbarOffset();
       }
     }
-    if (isFixed && !isOffsetParentAnElement && documentElement) {
-      setLeftRTLScrollbarOffset();
+
+    // If the <body> scrollbar appears on the left (e.g. RTL systems). Use
+    // Firefox with layout.scrollbar.side = 3 in about:config to test this.
+    if (!isOffsetParentAnElement && documentElement) {
+      offsets.x = getWindowScrollBarX(documentElement);
     }
     const htmlOffset = documentElement && !isOffsetParentAnElement && !isFixed ? getHTMLOffset(documentElement, scroll) : createCoords(0);
     const x = rect.left + scroll.scrollLeft - offsets.x - htmlOffset.x;
@@ -690,7 +693,7 @@
   }
 
   // https://samthor.au/2021/observing-dom/
-  function observeMove(element, onMove) {
+  function observeMove(element, onMove, ancestorResize) {
     let io = null;
     let timeoutId;
     const root = getDocumentElement(element);
@@ -733,29 +736,28 @@
       let isFirstUpdate = true;
       function handleObserve(entries) {
         const ratio = entries[0].intersectionRatio;
+
+        // The entry is a snapshot, so the reference may have moved since the
+        // intersection was computed (under performance constraints, or between
+        // consecutive frames of a multi-frame layout shift). The reported ratio
+        // and the observed area are stale in that case and cannot be trusted to
+        // detect subsequent movement, so refresh regardless of the ratio.
+        if (!rectsAreEqual(elementRectForRootMargin, element.getBoundingClientRect())) {
+          return refresh();
+        }
         if (ratio !== threshold) {
           if (!isFirstUpdate) {
             return refresh();
           }
           if (!ratio) {
-            // If the reference is clipped, the ratio is 0. Throttle the refresh
-            // to prevent an infinite loop of updates.
+            // If the reference is clipped in place, the ratio is 0. Throttle
+            // the refresh to prevent an infinite loop of updates.
             timeoutId = setTimeout(() => {
               refresh(false, 1e-7);
             }, 1000);
           } else {
             refresh(false, ratio);
           }
-        }
-        if (ratio === 1 && !rectsAreEqual(elementRectForRootMargin, element.getBoundingClientRect())) {
-          // It's possible that even though the ratio is reported as 1, the
-          // element is not actually fully within the IntersectionObserver's root
-          // area anymore. This can happen under performance constraints. This may
-          // be a bug in the browser's IntersectionObserver implementation. To
-          // work around this, we compare the element's bounding rect now with
-          // what it was at the time we created the IntersectionObserver. If they
-          // are not equal then the element moved, so we refresh.
-          refresh();
         }
         isFirstUpdate = false;
       }
@@ -773,8 +775,18 @@
       }
       io.observe(element);
     }
+    const win = getWindow(element);
+    // The window is a resize ancestor, so when `ancestorResize` is enabled its
+    // listener already runs the update on resize. Here we only need to rebuild
+    // the `IntersectionObserver` for the new root size, skipping a redundant
+    // update. When `ancestorResize` is disabled, this becomes the sole update.
+    const handleResize = () => refresh(ancestorResize);
+    win.addEventListener('resize', handleResize);
     refresh(true);
-    return cleanup;
+    return () => {
+      win.removeEventListener('resize', handleResize);
+      cleanup();
+    };
   }
 
   /**
@@ -799,12 +811,10 @@
     const referenceEl = unwrapElement(reference);
     const ancestors = ancestorScroll || ancestorResize ? [...(referenceEl ? getOverflowAncestors(referenceEl) : []), ...(floating ? getOverflowAncestors(floating) : [])] : [];
     ancestors.forEach(ancestor => {
-      ancestorScroll && ancestor.addEventListener('scroll', update, {
-        passive: true
-      });
+      ancestorScroll && ancestor.addEventListener('scroll', update);
       ancestorResize && ancestor.addEventListener('resize', update);
     });
-    const cleanupIo = referenceEl && layoutShift ? observeMove(referenceEl, update) : null;
+    const cleanupIo = referenceEl && layoutShift ? observeMove(referenceEl, update, ancestorResize) : null;
     let reobserveFrame = -1;
     let resizeObserver = null;
     if (elementResize) {
@@ -943,11 +953,9 @@
     // multiple lifecycle resets re-use the same result. It only lives for a
     // single call. If other functions become expensive, we can add them as well.
     const cache = new Map();
-    const mergedOptions = {
-      platform,
-      ...options
-    };
+    const mergedOptions = options != null ? options : {};
     const platformWithCache = {
+      ...platform,
       ...mergedOptions.platform,
       _c: cache
     };

--- a/modules/lib/foreign-resources.yaml
+++ b/modules/lib/foreign-resources.yaml
@@ -2,10 +2,10 @@ floatingui-core:
   license: MIT
   homepage: https://floating-ui.com
   authors: Floating UI authors
-  version: 1.7.5
+  version: 1.8.0
   type: tar
-  src: https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz
-  integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==
+  src: https://registry.npmjs.org/@floating-ui/core/-/core-1.8.0.tgz
+  integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==
 
   dest:
     package/dist/floating-ui.core.umd.js:
@@ -16,10 +16,10 @@ floatingui-dom:
   license: MIT
   homepage: https://floating-ui.com
   authors: Floating UI authors
-  version: 1.7.6
+  version: 1.8.0
   type: tar
-  src: https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz
-  integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==
+  src: https://registry.npmjs.org/@floating-ui/dom/-/dom-1.8.0.tgz
+  integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==
 
   dest:
     package/dist/floating-ui.dom.umd.js:


### PR DESCRIPTION
Updates the following foreign resources to their latest npm release:

| Component | Package | From | To |
| --- | --- | --- | --- |
| floatingui-core | [@floating-ui/core](https://www.npmjs.com/package/@floating-ui/core) | 1.7.5 | 1.8.0 |
| floatingui-dom | [@floating-ui/dom](https://www.npmjs.com/package/@floating-ui/dom) | 1.7.6 | 1.8.0 |

Bundled files were regenerated with MediaWiki's `manageForeignResources` maintenance script and verified against the updated integrity hashes.
