### PR TITLE
ci: use generated foreign resources PR titles

### DIFF
--- a/.github/workflows/update-foreign-resources.yml
+++ b/.github/workflows/update-foreign-resources.yml
@@ -14,7 +14,9 @@ jobs:
     with:
       project-type: extension
       project-name: FloatingUI
-      pr-title: "fix(deps): update Floating UI foreign resources"
+      # fix(deps) so merged update PRs cut a release-please patch release;
+      # the rest of the title is generated from the bumped packages.
+      pr-title-prefix: "fix(deps)"
     # Empty until the org defines PR_TOKEN (which would let update PRs
     # trigger CI); the workflow then falls back to GITHUB_TOKEN.
     secrets:


### PR DESCRIPTION
Adapts the caller to the renamed `pr-title-prefix` input from StarCitizenTools/mediawiki-ci-workflows#16: the shared workflow now generates Dependabot-style titles naming the bumped packages and versions (e.g. `fix(deps): bump @floating-ui/dom from 1.7.6 to 1.8.0`), so only the conventional-commit prefix is configured here.

**Merge after** StarCitizenTools/mediawiki-ci-workflows#16 — the old input is removed there, and this caller references the workflow `@main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
