### PR TITLE
build(deps-dev): update mediawiki/mediawiki-codesniffer requirement from 51.0.0 to 52.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
 		"composer/installers": ">=1.0.1"
 	},
 	"require-dev": {
-		"mediawiki/mediawiki-codesniffer": "51.0.0",
+		"mediawiki/mediawiki-codesniffer": "52.0.0",
 		"mediawiki/mediawiki-phan-config": "0.20.0",
 		"mediawiki/minus-x": "2.0.1",
 		"php-parallel-lint/php-console-highlighter": "1.0.0",


### PR DESCRIPTION
## Problem

Dependabot cannot propose this bump itself: codesniffer `51.0.0` exact-pins `squizlabs/php_codesniffer 3.13.5`, which is blocked by security advisory GHSA-hmqg-cxww-wqhq (CVE-2026-67434, [T434187](https://phabricator.wikimedia.org/T434187)) — its resolver refuses advisory-affected versions while resolving the *current* manifest, so every composer update job dies before it can compute the fix.

## Behaviour

`52.0.0` moves the pin to the patched PHPCS 3.13.6, clearing the advisory and unblocking future Dependabot composer runs. Verified in Docker: `composer update` resolves cleanly and `composer test` passes with no new sniff findings.

Same change as StarCitizenTools/mediawiki-skins-Citizen#1758, applied across the maintained repos.

## Merge order

**Requires StarCitizenTools/mediawiki-ci-workflows#18 first** — codesniffer 52 requires PHP ≥ 8.3, so the REL1_43/analyze legs fail until that matrix change lands on `main`. Re-run this PR's CI after it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)